### PR TITLE
Corrige instrução para reset do Console

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -67,8 +67,8 @@ namespace Exercicio_Musica
             Console.WriteLine("Certeza, eu superei");
             Console.WriteLine("Mas não manda mensagem outra vez");
             Console.WriteLine("Senão recairei");
-            Console.ForegroundColor=ConsoleColor.White;
             
+            Console.ResetColor();
 
 
 


### PR DESCRIPTION
A utilização de Console.ResetColor(); é a melhor prática, ao invés de atribuir a cor branca à fonte do Console.
Com o ResetColor(), você garante que a cor padrão seja reestabelecida, uma vez que a cor padrão do console do usuário pode ser o fundo branco com a fonte preta.